### PR TITLE
dup the fd, update deps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,15 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 4.0)
 
 find_package(cmake-fetch REQUIRED PATHS node_modules/cmake-fetch)
+find_package(cmake-harden REQUIRED PATHS node_modules/cmake-harden)
 
 project(tt C)
 
-fetch_package("github:libuv/libuv@1.48.0")
+fetch_package("github:libuv/libuv@1.51.0")
 
 add_library(tt OBJECT)
+
+harden(tt)
 
 set_target_properties(
   tt

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "homepage": "https://github.com/holepunchto/libtt#readme",
   "devDependencies": {
-    "cmake-fetch": "^1.0.0"
+    "cmake-fetch": "^1.4.9",
+    "cmake-harden": "^1.0.0"
   }
 }

--- a/src/unix/pty.c
+++ b/src/unix/pty.c
@@ -60,8 +60,8 @@ tt_pty_spawn (uv_loop_t *loop, tt_pty_t *handle, const tt_term_options_t *term, 
   int height = term ? term->height : 60;
 
   struct winsize size = {
-    .ws_col = width,
-    .ws_row = height,
+    .ws_col = (unsigned short) width,
+    .ws_row = (unsigned short) height,
   };
 
   int res = openpty(&primary, &replica, NULL, NULL, &size);
@@ -98,8 +98,18 @@ tt_pty_spawn (uv_loop_t *loop, tt_pty_t *handle, const tt_term_options_t *term, 
   handle->replica = replica;
   handle->pid = handle->process.pid;
 
-  err = uv_tty_init(loop, &handle->tty, primary, 0);
-  assert(err == 0);
+
+  int tty_fd = dup(primary);
+  if (tty_fd < 0) {
+    err = uv_translate_sys_error(errno);
+    goto err;
+  }
+
+  err = uv_tty_init(loop, &handle->tty, tty_fd, 0);
+  if (err < 0) {
+    close(tty_fd);
+    goto err;
+  }
   handle->active++;
 
   return 0;
@@ -169,8 +179,8 @@ tt_pty_write (tt_pty_write_t *req, tt_pty_t *handle, const uv_buf_t bufs[], unsi
 int
 tt_pty_resize (tt_pty_t *handle, int width, int height) {
   struct winsize size = {
-    .ws_col = width,
-    .ws_row = height,
+    .ws_col = (unsigned short) width,
+    .ws_row = (unsigned short) height,
   };
 
   int res;


### PR DESCRIPTION
I was finding an issue on macos where the same fd was used across pty instances, the first pty would close and libuv closes the fd, and then libuv would close the fd for the second pty thinking it had already dealt with it.

My impression is that didn't happen in libuv@1.48.0 but started in a release some time between then and 1.51.0.

Also updated cmake, libuv, and cmake-fetch and added cmake-harden.